### PR TITLE
Session Planning and Discussion

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -155,3 +155,22 @@
     url = {https://mlflow.org},
     keywords = {machine learning, experiment tracking, model management, artifacts logging},
 }
+
+@manual{amd_ug1354_kv260,
+  title        = {KV260 Vision AI Starter Kit},
+  subtitle     = {Vitis AI Library User Guide (UG1354), Version 2.5},
+  author       = {{AMD Xilinx}},
+  organization = {Advanced Micro Devices, Inc.},
+  year         = {2022},
+  note         = {Section ``KV260 Vision AI Starter Kit'' describes that one B4096 DPU core in PL delivers 1.23~TOPS INT8 peak performance and provides throughput at 300\,MHz for various models},
+  url          = {https://docs.amd.com/r/2.5-English/ug1354-xilinx-ai-sdk/KV260-Vision-AI-Starter-Kit}
+}
+
+@online{amd_kv260_b4096_forum,
+  author  = {{AMD Support Community}},
+  title   = {With Kria KV260, how many cores in DPU and how many DPUs we can integrate in KV260 at most?},
+  year    = {2024},
+  note    = {AMD engineer notes that the maximum size of DPU implemented for K26 SoMs or KV260 is B4096 at 300\,MHz, single core},
+  url     = {https://adaptivesupport.amd.com/s/question/0D54U000088eNqJSAU/with-kria-kv260-how-many-cores-in-dpu-and-how-many-dpus-we-can-integrate-in-kv260-at-most?language=en_US},
+  urldate = {2025-11-13}
+}

--- a/sections/04-design.tex
+++ b/sections/04-design.tex
@@ -325,7 +325,7 @@ The AMD Kria KV260 provides an excellent balance of performance and power effici
 \end{itemize}
 
 \subsubsection{DPU Architecture Options}
-The KV260's FPGA fabric offers flexibility in DPU configuration. The maximum single-core DPU configuration for K26 SoMs and KV260 is the B4096 architecture (feature customized at 300MHz). However, the FPGA fabric technically supports alternative configurations:
+The KV260's FPGA fabric offers flexibility in DPU configuration. The maximum single-core DPU configuration for K26 SoM and KV260 is the B4096 architecture (feature customized at 300MHz)~\cite{amd_ug1354_kv260,amd_kv260_b4096_forum}. However, the FPGA fabric technically supports alternative configurations:
 
 \begin{itemize}
 \item \textbf{Single Large Core:} B4096 DPU at 300MHz (current implementation)


### PR DESCRIPTION
Add comprehensive documentation of the DPU architecture decision to clarify that the project uses a single B4096 DPU core rather than exploring dual smaller DPUs (B1024/B512). This decision was directed by the client despite both our team and a previous ISU team concluding that dual DPUs would be advantageous for the workload.

Changes:
- Add new design decision section explaining single DPU constraint
- Document technical alternatives (B4096 vs dual B1024/B512)
- Clarify impact on optimization strategy (software-level vs hardware-level)
- Add DPU architecture options subsection to technology considerations

This constraint is important context for understanding why the project focuses on scheduling and resource sharing rather than hardware parallelism.