### PR TITLE
Remove development challenges section from document

### DIFF
--- a/sections/06-implementation.tex
+++ b/sections/06-implementation.tex
@@ -148,15 +148,6 @@ The model training process utilizes a comprehensive eye-tracking dataset with ca
 \item \textbf{Performance Optimization}: Achieving target pipelined throughput of 8.3ms average per frame (33.2ms total for 4 frames)
 \end{itemize}
 
-\subsection{Development Challenges}\label{subsec:development-challenges}
-
-\begin{itemize}
-\item \textbf{FPGA Development Complexity}: Learning curve associated with Vitis-AI and hardware acceleration development
-\item \textbf{Testing on Embedded Hardware}: Limited debugging tools compared to traditional software development environments
-\item \textbf{Integration Complexity}: Coordinating multiple algorithm implementations with sequential DPU access scheduling
-\item \textbf{Performance Profiling}: Identifying bottlenecks in pipelined processing architecture
-\end{itemize}
-
 \section{Future Implementation Plans}\label{subsec:future-implementation}
 
 \subsection{Short-term Goals (Next 4 weeks)}\label{subsec:short-term-goals}


### PR DESCRIPTION
This pull request removes the entire "Development Challenges" subsection from the implementation documentation. The section previously outlined difficulties related to FPGA development, testing, integration, and performance profiling.

Documentation update:

* Removed the `Development Challenges` subsection from `sections/06-implementation.tex`, including items about FPGA development complexity, testing on embedded hardware, integration complexity, and performance profiling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed development challenges section from implementation documentation, streamlining the narrative and focusing on core content areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->