### PR TITLE
Remove Lessons Learned section

### DIFF
--- a/sections/07-conclusion.tex
+++ b/sections/07-conclusion.tex
@@ -46,26 +46,6 @@ The potential social impact of this project extends beyond technical achievement
 \item \textbf{Caregiver Support}: Reduced burden on caregivers through automated monitoring and alert systems
 \end{itemize}
 
-\section{Lessons Learned}\label{sec:lessons-learned}
-
-\subsection{Technical Lessons}\label{subsec:technical-lessons}
-
-\begin{itemize}
-\item \textbf{Hardware-Software Co-design}: Considering hardware constraints throughout software development
-\item \textbf{Performance Optimization}: The critical role of systematic profiling and bottleneck identification in achieving performance goals
-\item \textbf{Testing Methodology}: The value of comprehensive testing strategies, especially for embedded systems with limited debugging capabilities
-\item \textbf{Resource Management}: The complexity of managing shared resources in multi-algorithm environments
-\end{itemize}
-
-\subsection{Project Management Lessons}\label{subsec:management-lessons}
-
-\begin{itemize}
-\item \textbf{Adaptive Planning}: The importance of flexible planning approaches that can accommodate technical challenges
-\item \textbf{Team Dynamics}: The value of diverse skills and perspectives in solving complex technical problems
-\item \textbf{Communication}: The critical role of clear communication with both team members and stakeholders
-\item \textbf{Documentation}: Maintaining comprehensive documentation throughout development
-\end{itemize}
-
 \section{Final Reflections}\label{sec:final-reflections}
 
 This project represents a significant achievement in the intersection of artificial intelligence, embedded systems, and assistive technology. By successfully addressing the complex challenge of optimizing semantic segmentation for real-time eye tracking, we have demonstrated that thoughtful algorithm design and resource management can overcome significant hardware limitations.


### PR DESCRIPTION
This pull request removes the "Lessons Learned" section from the conclusion of the project report, streamlining the document by eliminating detailed reflections on technical and project management experiences.

Removed content:

* The entire `Lessons Learned` section, including both `Technical Lessons` and `Project Management Lessons` subsections, which covered topics such as hardware-software co-design, performance optimization, testing methodology, resource management, adaptive planning, team dynamics, communication, and documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the "Lessons Learned" section from the conclusion, streamlining the document structure while maintaining other key sections including Summary of Achievements, Impact and Significance, Final Reflections, and Acknowledgments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->