### PR TITLE
Fix these issues

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -156,18 +156,6 @@
     keywords = {machine learning, experiment tracking, model management, artifacts logging},
 }
 
-@techreport{ieee2952-2023,
-    type = {Standard},
-    key = {IEEE 2952-2023},
-    month = {September},
-    year = {2023},
-    title = {{IEEE} Standard for Secure Computing Based on Trusted Execution Environment ({TEE})},
-    volume = {2952-2023},
-    doi = {10.1109/IEEESTD.2023.10266982},
-    institution = {IEEE},
-    keywords = {trusted execution environment, TEE, secure computing, security},
-}
-
 @techreport{ieee2802-2022,
     type = {Standard},
     key = {IEEE 2802-2022},
@@ -180,18 +168,6 @@
     keywords = {artificial intelligence, medical devices, AI safety, terminology},
 }
 
-@techreport{ieee7002-2022,
-    type = {Standard},
-    key = {IEEE 7002-2022},
-    month = {May},
-    year = {2022},
-    title = {{IEEE} Standard for Data Privacy Process},
-    volume = {7002-2022},
-    doi = {10.1109/IEEESTD.2022.9792905},
-    institution = {IEEE},
-    keywords = {data privacy, privacy process, data protection, GDPR},
-}
-
 @techreport{ieee3129-2023,
     type = {Standard},
     key = {IEEE 3129-2023},
@@ -202,30 +178,6 @@
     doi = {10.1109/IEEESTD.2023.10273450},
     institution = {IEEE},
     keywords = {artificial intelligence, image recognition, robustness testing, AI evaluation},
-}
-
-@techreport{ieee3156-2023,
-    type = {Standard},
-    key = {IEEE 3156-2023},
-    month = {February},
-    year = {2024},
-    title = {{IEEE} Standard for Requirements of Privacy-Preserving Computation Integrated Platform},
-    volume = {3156-2023},
-    doi = {10.1109/IEEESTD.2023.10234336},
-    institution = {IEEE},
-    keywords = {privacy-preserving computation, secure computation, data privacy, platform requirements},
-}
-
-@techreport{ieee2842-2021,
-    type = {Standard},
-    key = {IEEE 2842-2021},
-    month = {December},
-    year = {2021},
-    title = {{IEEE} Recommended Practice for Secure Multi-party Computation},
-    volume = {2842-2021},
-    doi = {10.1109/IEEESTD.2021.9645461},
-    institution = {IEEE},
-    keywords = {secure multi-party computation, MPC, cryptographic protocols, secure computation},
 }
 
 @manual{amd_ug1354_kv260,

--- a/sections/02-requirements.tex
+++ b/sections/02-requirements.tex
@@ -127,21 +127,9 @@ For the demonstration of the VisionAssist system, the user interface requirement
 The following IEEE standards are applicable to this project and guide the development and evaluation processes:
 
 \begin{description}
-\item[IEEE 2952--2023~\cite{ieee2952-2023}] \textit{IEEE Standard for Secure Computing Based on Trusted Execution Environment} \\
-Trusted Execution Environments (TEEs) are used to protect sensitive data and computations. This standard ensures that systems using TEEs follow security best practices, reducing the risk of unauthorized access or tampering.
-
 \item[IEEE 2802--2022~\cite{ieee2802-2022}] \textit{IEEE Standard for Performance and Safety Evaluation of AI-Based Medical Devices: Terminology} \\
-This standard provides clear terms and definitions for evaluating the performance and safety of AI-based medical devices. It helps ensure these devices are reliable and effective in real-world medical settings.
-
-\item[IEEE 7002--2022~\cite{ieee7002-2022}] \textit{IEEE Standard for Data Privacy Process} \\
-This standard outlines best practices for protecting user data and ensuring privacy. It helps organizations comply with regulations and build trust with users when handling sensitive information.
+This standard provides terminology and definitions for evaluating the performance and safety of AI-based medical devices. It is directly applicable to VisionAssist as an AI-powered assistive technology system for medical monitoring. The standard guides our evaluation methodology to ensure the system is reliable and effective in real-world medical settings, particularly for real-time detection of medical episodes through eye tracking and posture analysis.
 
 \item[IEEE 3129--2023~\cite{ieee3129-2023}] \textit{IEEE Standard for Robustness Testing and Evaluation of AI-Based Image Recognition Services} \\
-This standard provides guidelines for testing AI-based image recognition systems to ensure they work reliably under different conditions. It helps identify and fix issues that could arise from unexpected inputs or scenarios.
-
-\item[IEEE 3156--2023~\cite{ieee3156-2023}] \textit{IEEE Standard for Requirements of Privacy-Preserving Computation Integrated Platforms} \\
-Privacy-preserving computation allows data to be processed without exposing sensitive information. This standard defines the requirements for platforms that support such computations, ensuring they protect user privacy.
-
-\item[IEEE 2842--2021~\cite{ieee2842-2021}] \textit{IEEE Recommended Practice for Secure Multi-Party Computation} \\
-Secure multi-party computation lets multiple parties work together on shared data without revealing their individual inputs. This standard provides guidance for implementing these protocols, making collaborative computing safer for sensitive applications like healthcare and finance.
+This standard provides guidelines for testing AI-based image recognition systems to ensure they operate reliably under varying conditions. It is directly applicable to our U-Net semantic segmentation model for eye tracking, which must maintain 99.8\% accuracy across different lighting conditions, user populations, and environmental factors. The standard informs our robustness testing methodology described in Chapter~\ref{chap:testing}, including stress testing, lighting variation testing, and long-term stability validation.
 \end{description}

--- a/sections/05-testing.tex
+++ b/sections/05-testing.tex
@@ -249,12 +249,12 @@ Automated regression tests executed following code changes to verify system stab
 
 \subsection{IEEE Standards Compliance}\label{subsec:ieee-compliance}
 
-The testing methodology aligned with applicable IEEE standards:
+The testing methodology was designed in accordance with applicable IEEE standards for AI-based medical devices:
 
 \begin{itemize}
-\item \textbf{IEEE 3129--2023}~\cite{ieee3129-2023}: Robustness testing and evaluation of AI-based image recognition services
-\item \textbf{IEEE 2802--2022}~\cite{ieee2802-2022}: Performance and safety evaluation of AI-based medical devices
-\item \textbf{IEEE 7002--2022}~\cite{ieee7002-2022}: Data privacy process compliance validation
+\item \textbf{IEEE 3129--2023}~\cite{ieee3129-2023}: Our robustness testing approach follows this standard's guidelines for evaluating AI-based image recognition systems. We conducted comprehensive testing across varying lighting conditions, stress scenarios, and long-term stability validation to ensure the U-Net semantic segmentation model maintains reliability under diverse operating conditions.
+
+\item \textbf{IEEE 2802--2022}~\cite{ieee2802-2022}: Our performance and safety evaluation methodology aligns with this standard's terminology and best practices for AI-based medical devices. Testing focused on critical performance metrics (throughput, accuracy, latency) and safety-critical validation to ensure the system is reliable for real-world medical monitoring applications.
 \end{itemize}
 
 \subsection{Test Documentation}\label{subsec:test-documentation}


### PR DESCRIPTION
…chnologies

Remove four IEEE standards that were inappropriately listed:
- IEEE 2952 (TEE): System does not use Trusted Execution Environments
- IEEE 2842 (MPC): System does not use Multi-Party Computation
- IEEE 3156 (Privacy-Preserving): System does not use cryptographic privacy techniques
- IEEE 7002 (Data Privacy Process): No formal data privacy process implemented

Retain only applicable standards:
- IEEE 2802 (AI Medical Devices): Directly applicable to medical assistive technology
- IEEE 3129 (AI Image Recognition): Directly applicable to U-Net semantic segmentation

Enhanced descriptions for remaining standards to explicitly connect them to actual system implementation, preventing future confusion about applicability.

System achieves privacy through on-device processing (privacy by design), not through advanced cryptographic techniques that would require these standards.