### PR TITLE
Remove repetitive content from technical document

### DIFF
--- a/sections/02-requirements.tex
+++ b/sections/02-requirements.tex
@@ -8,8 +8,8 @@
 \item \textbf{Algorithm Optimization and Pipelining:}
    \begin{itemize}
    \item Optimize the U-Net semantic segmentation algorithm to enable efficient pipelined processing with CPU-based preprocessing and postprocessing stages.
-   \item Implement a pipelined architecture where CPU threads handle data preparation while the DPU executes sequential neural network inference, maximizing overall system throughput.
-   \item Ensure the pipeline maintains data consistency and synchronization between stages, with proper scheduling to share the DPU sequentially among semantic segmentation and other algorithms (e.g., blink detection, eye tracking).
+   \item Implement a pipelined architecture that maximizes overall system throughput through overlapped CPU and DPU processing.
+   \item Ensure the pipeline maintains data consistency and synchronization between stages with proper DPU scheduling across algorithms.
    \end{itemize}
 
 \item \textbf{System Throughput:}
@@ -21,7 +21,7 @@
 \item \textbf{Resource Efficiency:}
    \begin{itemize}
    \item Optimize memory and FPGA resource usage to accommodate the additional overhead of pipelined execution and multi-threaded CPU processing.
-   \item Ensure efficient sequential scheduling of the DPU among semantic segmentation and other algorithms, as the DPU can only execute one xmodel inference at a time.
+   \item Ensure efficient sequential scheduling of the DPU among semantic segmentation and other algorithms.
    \end{itemize}
 
 \item \textbf{Error Handling in Pipeline:}
@@ -96,7 +96,7 @@ For the demonstration of the VisionAssist system, the user interface requirement
 
 \item \textbf{DPU Utilization:}
    \begin{itemize}
-   \item Develop a sequential scheduling strategy for DPU access, as the DPU can only execute one xmodel inference at a time. The scheduler must efficiently coordinate between blink detection and eye-tracking submodules without causing bottlenecks.
+   \item Develop a sequential scheduling strategy for DPU access that efficiently coordinates between blink detection and eye-tracking submodules without causing bottlenecks.
    \end{itemize}
 \end{enumerate}
 

--- a/sections/03-project-plan.tex
+++ b/sections/03-project-plan.tex
@@ -22,7 +22,7 @@ Weekly team meetings were held to review sprint progress, address blockers, and 
 
 \section{Task Decomposition}\label{sec:task-decomposition}
 
-Our project involved optimizing the semantic segmentation U-Net algorithm by implementing a pipelined architecture that leveraged multi-threaded CPU processing alongside sequential DPU execution\@. The key objective was to increase system throughput from 160 ms per frame to approximately 8.3\ ms per frame average (33.2\ ms total for 4 frames in the pipeline)\@. The following tasks and subtasks were identified:
+Our project involved optimizing the semantic segmentation U-Net algorithm by implementing a pipelined architecture that leveraged multi-threaded CPU processing alongside sequential DPU execution\@. The key objective was to achieve target throughput of 60 FPS for real-time medical monitoring. The following tasks and subtasks were identified:
 
 \subsection{Task 1: Algorithm Performance Optimization}
 \begin{itemize}
@@ -80,7 +80,7 @@ The following key milestones were identified for the project, along with their a
 \subsection{Milestone 1: Pipeline Architecture Design}
 \begin{itemize}
 \item \textbf{Completion Date}: Week 8
-\item \textbf{Metrics}: Validated pipelined architecture design with CPU preprocessing/postprocessing and sequential DPU inference
+\item \textbf{Metrics}: Validated pipelined architecture design with overlapped CPU and DPU processing
 \item \textbf{Evaluation Criteria}: Architecture design maintains output accuracy equivalent to original algorithm
 \end{itemize}
 
@@ -205,7 +205,7 @@ The critical path for this project follows the mathematical division of the algo
 \item \textbf{Severity}: High
 \item \textbf{Mitigation Strategies}:
   \begin{itemize}
-  \item Design efficient DPU scheduling system to maximize utilization while the DPU processes one inference at a time
+  \item Design efficient DPU scheduling system to maximize utilization
   \item Employ effective multi-threading paradigms for CPU-based preprocessing and postprocessing
   \item Utilize synchronization primitives to coordinate between pipeline stages and avoid resource contention
   \item Profile and optimize critical code sections to maximize overall throughput

--- a/sections/04-design.tex
+++ b/sections/04-design.tex
@@ -40,14 +40,14 @@ Several approaches have been used to implement semantic segmentation for eye tra
 \begin{enumerate}
 \item \textbf{Wang et al. (2021)}~\cite{wang2021} proposed ``EfficientEye: A Lightweight Semantic Segmentation Framework for Eye Tracking'', which achieved good accuracy but still required substantial computational resources. Their approach reduced model size but processing speed remained at approximately 120 ms per frame.
 
-\item \textbf{Previous Project Iteration} implemented a standard U-Net architecture on the Kria KV260 board with an accuracy of 99.8\% IoU but could only process a single frame every 160ms, which is insufficient for real-time application needs.
+\item \textbf{Previous Project Iteration} implemented a standard U-Net architecture on the Kria KV260 board with high accuracy (99.8\% IoU) but could only process a single frame every 160ms, which is insufficient for real-time application needs.
 
 \item \textbf{Commercial Solutions} like Tobii Pro Fusion offer high-speed eye tracking (250 Hz) but require dedicated hardware and specialized processors, making them expensive and difficult to integrate into existing assistive devices.
 \end{enumerate}
 
 \subsubsection{Advantages of Our Approach}
 \begin{itemize}
-\item Maintains high accuracy (99.8\% IoU) while significantly improving processing speed
+\item Maintains high accuracy while significantly improving processing speed
 \item Utilizes existing hardware (Kria KV260) without requiring costly upgrades
 \item Implements a pipelined approach that maximizes system throughput through overlapped CPU and DPU processing
 \item Integrates with existing assistive wheelchair technology ecosystem
@@ -76,14 +76,14 @@ Our project demonstrates significant technical complexity in both its components
 
 \item \textbf{Challenging Requirements:}
    \begin{itemize}
-   \item \textbf{Speed Improvement:} Increasing throughput (from 160ms to approximately 8.3ms per frame average through pipelining) exceeds typical optimization gains in the industry
-   \item \textbf{Accuracy Maintenance:} Preserving 99.8\% IoU accuracy while implementing complex pipelined processing is significantly more challenging than standard optimization
+   \item \textbf{Speed Improvement:} Achieving near 5x throughput improvement through pipelining exceeds typical optimization gains in the industry
+   \item \textbf{Accuracy Maintenance:} Preserving high accuracy while implementing complex pipelined processing is significantly more challenging than standard optimization
    \item \textbf{Resource Constraints:} Working within the limited memory (4GB) and single-DPU architecture of the Kria board requires innovative scheduling solutions
    \item \textbf{Real-time Performance:} Meeting the 60 frames per second requirement is at the upper end of what is possible with current embedded AI systems
    \end{itemize}
 \end{enumerate}
 
-The combination of these elements, particularly maintaining accuracy while implementing efficient pipelined execution with sequential DPU access scheduling across multiple algorithms, represents technical complexity beyond standard engineering solutions.
+The combination of these elements, particularly maintaining accuracy while implementing efficient pipelined execution with resource scheduling across multiple algorithms, represents technical complexity beyond standard engineering solutions.
 
 \section{Design Exploration}\label{sec:design-exploration}
 
@@ -95,7 +95,7 @@ We have identified the following key design decisions that are critical to the s
 \item \textbf{Resource Scheduling Approach}
    \begin{itemize}
    \item \textbf{Decision:} Implement an efficient sequential scheduling system for DPU access, recognizing that the DPU can only execute one xmodel inference at a time. The system uses round-robin or priority-based scheduling to coordinate access among semantic segmentation and other algorithms.
-   \item \textbf{Importance:} This is fundamental to achieving our throughput goal while ensuring Algorithms 1, 2, and 3 can collect their required periodic data. Without effective sequential scheduling, semantic segmentation would monopolize the DPU, preventing other critical algorithms from functioning correctly. The scheduling approach must provide fair resource allocation while maintaining the 99.8\% IoU accuracy target.
+   \item \textbf{Importance:} This is fundamental to achieving our throughput goal while ensuring Algorithms 1, 2, and 3 can collect their required periodic data. Without effective sequential scheduling, semantic segmentation would monopolize the DPU, preventing other critical algorithms from functioning correctly. The scheduling approach must provide fair resource allocation while maintaining accuracy targets.
    \end{itemize}
 
 \item \textbf{DPU Access Management}
@@ -165,18 +165,18 @@ Another important note is that the scheduling system must account for operating 
 
 Our Semantic Segmentation Optimization project aims to enhance the performance of a U-Net-based eye tracking system for individuals with disabilities, particularly those with cerebral palsy. This system helps monitor eye movements to detect potential medical issues and can automatically reposition users to prevent incidents, improving safety and quality of life.
 
-The current implementation processes a single frame in 160ms, which is insufficient for real-time monitoring. Our optimized design implements a pipelined architecture that leverages multi-threaded CPU processing alongside sequential DPU execution to achieve a throughput of approximately 8.3ms per frame average (33.2ms total for 4 frames in the pipeline), effectively increasing the processing speed by nearly 5 times.
+The current implementation processes a single frame in 160ms, which is insufficient for real-time monitoring. Our optimized design implements a pipelined architecture that leverages multi-threaded CPU processing alongside sequential DPU execution to achieve approximately 8.3ms per frame average throughput (33.2ms total for 4 frames), effectively increasing the processing speed by nearly 5 times.
 
 At a high level, our system:
 
 \begin{enumerate}
 \item Captures eye movement images through a camera
-\item Processes these images using a pipelined semantic segmentation architecture where CPU threads handle preprocessing while the DPU executes neural network inference sequentially, removing reflections and identifying the pupil
+\item Processes these images using pipelined semantic segmentation to remove reflections and identify the pupil
 \item Tracks the eye's position and detects blinks in real-time
 \item Provides this information to the assistive wheelchair technology for appropriate response
 \end{enumerate}
 
-The key innovation in our design is the approach to pipelined processing and efficient sequential DPU scheduling on the AMD Kria KV260 board, which has limited memory and a single DPU that can only execute one xmodel inference at a time, but powerful acceleration capabilities when properly leveraged.
+The key innovation in our design is the approach to pipelined processing and efficient sequential DPU scheduling on the AMD Kria KV260 board, which has limited memory and a single DPU, but powerful acceleration capabilities when properly leveraged.
 
 \subsection{Detailed Design}\label{subsec:detailed-design}
 
@@ -199,7 +199,7 @@ Our semantic segmentation optimization system consists of the following key comp
 \item \textbf{U-Net Semantic Segmentation Algorithm}
    \begin{itemize}
    \item \textbf{Purpose:} Processes eye images to create pixel-level segmentation for pupil identification
-   \item \textbf{Capabilities:} Achieves 99.8\% IoU accuracy while meeting performance requirements
+   \item \textbf{Capabilities:} Achieves target accuracy while meeting performance requirements
    \item \textbf{Function:} Enables reliable eye tracking by producing high-quality segmentation maps
    \end{itemize}
 
@@ -238,9 +238,9 @@ Our system implements a four-stage processing pipeline:
 
 \item \textbf{Pipelined Semantic Segmentation}~\cite{zhao2023parallel}
    \begin{itemize}
-   \item Pipelined U-Net processing with overlapped CPU preprocessing/postprocessing and sequential DPU inference
+   \item Pipelined U-Net processing with overlapped CPU and DPU stages
    \item Efficient throughput of multiple frames through pipeline stages
-   \item Sequential DPU scheduling and management to coordinate access among multiple algorithms
+   \item DPU scheduling to coordinate access among algorithms
    \end{itemize}
 
 \item \textbf{Feature Extraction and Analysis}
@@ -340,7 +340,7 @@ The U-Net architecture~\cite{ronneberger2015} is particularly well-suited for ou
 \begin{itemize}
 \item \textbf{Encoder-Decoder Structure:} Provides both high-level context and detailed localization
 \item \textbf{Skip Connections:} Preserves fine-grained spatial information crucial for pupil detection
-\item \textbf{Proven Performance:} Demonstrated 99.8\% IoU accuracy in our current implementation
+\item \textbf{Proven Performance:} Demonstrated required accuracy in baseline implementation
 \item \textbf{Modular Design:} Amenable to division across multiple processing cores
 \end{itemize}
 
@@ -371,16 +371,16 @@ Our comprehensive benchmarking has evaluated both single-model and split-model i
 
 \subsection{Implementation Challenges:}
 \begin{itemize}
-\item Single DPU constraint requiring sequential scheduling among multiple algorithms
+\item Single DPU constraint requiring scheduling among multiple algorithms
 \item Memory bandwidth constraints affecting data flow between processing stages
 \item Thread synchronization overhead in pipelined processing
-\item Balancing sequential DPU access time allocation between multiple algorithms
+\item Balancing DPU access time allocation between multiple algorithms
 \end{itemize}
 
 \subsection{Future Implementation Plans:}
 \begin{itemize}
-\item Complete pipelined architecture implementation with optimized CPU preprocessing and postprocessing
-\item Implement comprehensive sequential DPU scheduling system
-\item Optimize memory access patterns and buffer management for pipelined data flow
+\item Complete pipelined architecture implementation with optimized CPU processing stages
+\item Implement comprehensive DPU scheduling system
+\item Optimize memory access patterns and buffer management
 \item Develop robust testing and validation framework
 \end{itemize}

--- a/sections/05-testing.tex
+++ b/sections/05-testing.tex
@@ -15,7 +15,7 @@ Early and continuous testing enabled rapid detection and resolution of issues be
 \begin{itemize}
 \item Testing each pipeline stage and the U-Net algorithm components as they were created
 \item Checking memory use and buffer management before building the full system
-\item Testing how sequential DPU access was scheduled during development
+\item Testing DPU access scheduling during development
 \end{itemize}
 
 \subsection{Testing Challenges}\label{subsec:testing-challenges}
@@ -24,9 +24,9 @@ The project encountered several significant testing challenges:
 
 \begin{itemize}
 \item Testing on FPGA hardware was different from normal software testing
-\item Ensuring pipelined threads and sequential DPU scheduling worked together correctly
+\item Ensuring pipelined threads and DPU scheduling worked together correctly
 \item Balancing speed and accuracy
-\item Verifying that memory was used correctly for pipelined data flow
+\item Verifying efficient memory use for pipelined data flow
 \end{itemize}
 
 \subsection{Testing Schedule}\label{subsec:testing-schedule}

--- a/sections/06-implementation.tex
+++ b/sections/06-implementation.tex
@@ -57,7 +57,7 @@ The U-Net semantic segmentation algorithm has been thoroughly analyzed for pipel
 
 \begin{itemize}
 \item \textbf{Architecture Review}: Complete understanding of encoder-decoder structure and skip connections
-\item \textbf{Pipeline Strategy}: Architectural approach developed for efficient pipelined processing with CPU preprocessing/postprocessing and sequential DPU inference
+\item \textbf{Pipeline Strategy}: Architectural approach developed for efficient pipelined processing with overlapped CPU and DPU stages
 \item \textbf{Accuracy Validation}: Current implementation achieves 98.8\% IoU accuracy, within target range of 99.8\%~\cite{wang2021}
 \item \textbf{Performance Baseline}: Comprehensive benchmarking completed for both single and split model architectures
 \end{itemize}
@@ -65,7 +65,7 @@ The U-Net semantic segmentation algorithm has been thoroughly analyzed for pipel
 \subsection{Resource Scheduling Implementation}\label{subsec:scheduling-implementation}
 
 \begin{itemize}
-\item \textbf{DPU Access Management}: Sequential scheduling system (round-robin) designed for fair DPU access allocation, recognizing that the DPU can only execute one xmodel inference at a time
+\item \textbf{DPU Access Management}: Sequential scheduling system (round-robin) designed for fair DPU access allocation
 \item \textbf{Thread Coordination}: Multi-threading framework implemented for CPU-based preprocessing and postprocessing~\cite{park2022thread}
 \item \textbf{Memory Management}: Optimized memory allocation strategy for efficient pipelined data flow~\cite{chen2022memory}
 \item \textbf{Synchronization}: Inter-thread communication mechanisms established for pipeline stage coordination
@@ -144,8 +144,8 @@ The model training process utilizes a comprehensive eye-tracking dataset with ca
 \begin{itemize}
 \item \textbf{Memory Constraints}: Working within 4GB DDR memory limitations while supporting pipelined processing across multiple algorithms
 \item \textbf{Thread Synchronization}: Ensuring proper coordination between pipeline processing threads without deadlocks or race conditions
-\item \textbf{Sequential DPU Scheduling}: Efficiently scheduling the single DPU (which can only execute one xmodel inference at a time) to balance semantic segmentation requirements with periodic data collection needs of auxiliary algorithms
-\item \textbf{Performance Optimization}: Achieving target pipelined throughput of 8.3ms average per frame (33.2ms total for 4 frames)
+\item \textbf{Sequential DPU Scheduling}: Efficiently scheduling the single DPU to balance semantic segmentation requirements with periodic data collection needs of auxiliary algorithms
+\item \textbf{Performance Optimization}: Achieving target pipelined throughput for real-time operation
 \end{itemize}
 
 \section{Future Implementation Plans}\label{subsec:future-implementation}
@@ -153,8 +153,8 @@ The model training process utilizes a comprehensive eye-tracking dataset with ca
 \subsection{Short-term Goals (Next 4 weeks)}\label{subsec:short-term-goals}
 
 \begin{itemize}
-\item Complete implementation of pipelined U-Net processing with CPU preprocessing/postprocessing and sequential DPU inference
-\item Optimize sequential DPU scheduling system for maximum throughput
+\item Complete implementation of pipelined U-Net processing
+\item Optimize DPU scheduling system for maximum throughput
 \item Implement comprehensive testing framework
 \item Validate accuracy maintenance across pipelined implementation
 \end{itemize}
@@ -162,8 +162,8 @@ The model training process utilizes a comprehensive eye-tracking dataset with ca
 \subsection{Medium-term Goals (Next 8 weeks)}\label{subsec:medium-term-goals}
 
 \begin{itemize}
-\item Achieve target pipelined performance of 8.3ms average per frame (33.2ms total for 4 frames)
-\item Complete integration testing with all auxiliary algorithms and sequential DPU scheduling
+\item Achieve target pipelined performance for real-time operation
+\item Complete integration testing with all auxiliary algorithms and DPU scheduling
 \item Optimize memory usage and buffer management for pipelined data flow
 \item Implement robust error handling and recovery mechanisms
 \end{itemize}

--- a/sections/07-conclusion.tex
+++ b/sections/07-conclusion.tex
@@ -8,7 +8,7 @@ This project has successfully addressed the critical challenge of optimizing sem
 
 \begin{itemize}
 \item \textbf{Algorithm Analysis}: Comprehensive analysis of the U-Net semantic segmentation architecture for pipelined processing optimization
-\item \textbf{Sequential DPU Scheduling}: Development of an efficient sequential DPU scheduling system that ensures fair access allocation across multiple algorithms, recognizing the constraint that the DPU can only execute one xmodel inference at a time
+\item \textbf{Sequential DPU Scheduling}: Development of an efficient sequential DPU scheduling system that ensures fair access allocation across multiple algorithms
 \item \textbf{Performance Optimization}: Pipelined architecture with multi-threaded CPU processing implementation for throughput improvements
 \item \textbf{Accuracy Preservation}: Maintained 98.8\% IoU accuracy, within the target range of 99.8\%
 \end{itemize}
@@ -31,7 +31,7 @@ Our project contributes to the field of embedded AI systems by demonstrating tha
 \begin{itemize}
 \item \textbf{Resource-Constrained AI}: Methods for optimizing AI performance on limited hardware platforms with single-DPU architectures
 \item \textbf{Real-Time Processing}: Techniques for achieving real-time performance in medical and assistive applications through efficient pipelined processing
-\item \textbf{Sequential Resource Scheduling}: Strategies for effective scheduling when hardware accelerators can only process one inference at a time
+\item \textbf{Sequential Resource Scheduling}: Strategies for effective scheduling with shared hardware accelerators
 \item \textbf{Edge Computing}: Advances in bringing AI capabilities to edge devices without cloud dependency
 \end{itemize}
 


### PR DESCRIPTION
Remove repetitive phrases and verbose technical descriptions to improve document clarity and conciseness while maintaining technical accuracy.

Key changes:
- Simplified "DPU can only execute one inference at a time" to avoid excessive repetition (kept in abstract and first design mention)
- Reduced verbose descriptions of pipelined execution architecture
- Streamlined accuracy metrics mentions (99.8% IoU) to essential contexts
- Simplified performance target descriptions (8.3ms per frame)
- Condensed sequential DPU scheduling explanations

This addresses feedback about document padding while preserving all essential technical information and maintaining clear communication of project requirements, design decisions, and implementation details.

Files modified:
- sections/02-requirements.tex: Simplified functional requirements
- sections/03-project-plan.tex: Streamlined objectives and milestones
- sections/04-design.tex: Reduced design decision redundancy
- sections/05-testing.tex: Simplified testing descriptions
- sections/06-implementation.tex: Condensed implementation details
- sections/07-conclusion.tex: Streamlined technical accomplishments