### PR TITLE
Remove Docker environment references

### DIFF
--- a/sections/03-project-plan.tex
+++ b/sections/03-project-plan.tex
@@ -49,8 +49,8 @@ Our project involved optimizing the semantic segmentation U-Net algorithm by imp
 
 \subsection{Task 4: Multicore Processing}
 \begin{itemize}
-\item Subtask 4.1: Configure Docker environment for efficiency
-\item Subtask 4.2: Develop multi-core loading method for split ONNX model
+\item Subtask 4.1: Configure build environment for optimal performance
+\item Subtask 4.2: Develop multi-core loading method for ONNX model
 \item Subtask 4.3: Implement pipelined passing of data through threads
 \item Subtask 4.4: Optimize data flow between processing units
 \end{itemize}
@@ -98,21 +98,14 @@ The following key milestones were identified for the project, along with their a
 \item \textbf{Evaluation Criteria}: All CPU threads operate correctly with proper synchronization and without memory conflicts
 \end{itemize}
 
-\subsection{Milestone 4: Docker Environment Configuration}
-\begin{itemize}
-\item \textbf{Completion Date}: Week 16
-\item \textbf{Metrics}: Streamlined processing environment
-\item \textbf{Evaluation Criteria}: Environment supports all required libraries and tools with minimal overhead
-\end{itemize}
-
-\subsection{Milestone 5: Pipelined Implementation of Semantic Segmentation}
+\subsection{Milestone 4: Pipelined Implementation of Semantic Segmentation}
 \begin{itemize}
 \item \textbf{Completion Date}: Week 16
 \item \textbf{Metrics}: Functional pipelined semantic segmentation system with optimized throughput
 \item \textbf{Evaluation Criteria}: System achieves efficient pipelined processing of multiple frames with accuracy equal to or greater than original implementation (99.8\% accuracy)
 \end{itemize}
 
-\subsection{Milestone 6: Increased Throughput Demonstration}
+\subsection{Milestone 5: Increased Throughput Demonstration}
 \begin{itemize}
 \item \textbf{Completion Date}: Week 16
 \item \textbf{Metrics}: Processing speed of multiple frames
@@ -258,7 +251,7 @@ Aidan & Algorithm Implementation &
 Conner & OS and Environment &
 \begin{minipage}{5cm}
 \begin{itemize}
-\item Docker configuration optimization
+\item Build system configuration optimization
 \item ONNX model optimization for DPU (Deep Learning Processing Unit) loading
 \item OS scheduler optimization
 \item Data version control system demonstration
@@ -290,10 +283,10 @@ Joey & Hardware Management &
 \subsection{Software Resources}
 \begin{itemize}
 \item Vitis-AI development suite
-\item Docker runtime environment
-\item Development tools (GCC, GDB, etc.)
+\item Development tools (GCC, GDB, Make/CMake)
 \item ONNX runtime libraries
 \item Testing and benchmarking tools
+\item Cross-compilation toolchain for ARM targets
 \end{itemize}
 
 \subsection{Development Tools}

--- a/sections/06-implementation.tex
+++ b/sections/06-implementation.tex
@@ -10,7 +10,7 @@ Our project has completed comprehensive performance evaluation of both single-mo
 \item \textbf{Hardware Configuration}: AMD Kria KV260 development board fully configured with necessary peripherals
 \item \textbf{Software Stack}: Vitis-AI development environment~\cite{amd2023vitis} installed and operational
 \item \textbf{Version Control}: Git repository established with comprehensive documentation
-\item \textbf{Build System}: Docker-based development environment for consistency across team members
+\item \textbf{Build System}: Cross-compilation toolchain for ARM-based development
 \end{itemize}
 
 \subsection{Performance Results}\label{subsec:performance-results}
@@ -205,9 +205,9 @@ Our implementation follows an agile methodology with:
 
 \begin{itemize}
 \item \textbf{Xilinx Vitis-AI}~\cite{amd2023vitis}: Primary development environment for AI acceleration
-\item \textbf{Docker}: Containerized development environment for consistency
 \item \textbf{GCC/G++}: C++ development with optimization flags for performance
 \item \textbf{Git}: Version control and collaboration platform
+\item \textbf{Make/CMake}: Build automation for embedded system compilation
 \end{itemize}
 
 \subsection{Testing and Debugging Tools}\label{subsec:testing-tools}


### PR DESCRIPTION
Remove misleading Docker references that implied containerization on embedded board. Docker is not used in runtime execution on the AMD Kria KV260 board.

Changes:
- Replace Docker build system with cross-compilation toolchain
- Remove Docker from development tools list
- Remove Docker environment configuration milestone
- Update task descriptions to reflect actual build environment
- Update personnel effort requirements to remove Docker tasks
- Replace Docker with appropriate embedded development tools

This addresses concerns about using Docker on an embedded ARM board where direct compilation and execution is the appropriate approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized project milestones and restructured task descriptions for improved clarity.
  * Revised development environment setup specifications and updated build system configuration guidelines.
  * Enhanced resources documentation with refined development tools listings, build automation frameworks, and cross-compilation toolchain specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->