### PR TITLE
Document ONNX graph splitting with Netron

### DIFF
--- a/references.bib
+++ b/references.bib
@@ -268,3 +268,11 @@
   howpublished={\url{https://onnxruntime.ai/}},
   note={Version: 1.19.0}
 }
+
+@misc{netron,
+  title={Netron: Visualizer for Neural Network, Deep Learning, and Machine Learning Models},
+  author={Roeder, Lutz},
+  year={2024},
+  howpublished={\url{https://github.com/lutzroeder/netron}},
+  note={Open-source neural network model visualizer supporting ONNX, TensorFlow, PyTorch, and other formats}
+}

--- a/sections/06-implementation.tex
+++ b/sections/06-implementation.tex
@@ -62,6 +62,19 @@ The U-Net semantic segmentation algorithm has been thoroughly analyzed for pipel
 \item \textbf{Performance Baseline}: Comprehensive benchmarking completed for both single and split model architectures
 \end{itemize}
 
+\subsubsection{ONNX Graph Analysis with Netron}\label{subsubsec:onnx-graph-analysis}
+
+To identify appropriate split points for dividing the U-Net model into segments for parallel processing, we utilized Netron~\cite{netron}, an open-source neural network visualization tool. Netron provides comprehensive visualization of ONNX model graphs, enabling detailed inspection of the network architecture including:
+
+\begin{itemize}
+\item \textbf{Node Identification}: Visual representation of all computational nodes in the ONNX graph, including convolutional layers, activation functions, pooling operations, and skip connections
+\item \textbf{Layer Connectivity}: Clear visualization of data flow between layers, essential for identifying valid split points that preserve model integrity
+\item \textbf{Tensor Dimensions}: Display of intermediate tensor shapes at each node, critical for understanding memory requirements and data transfer overhead between split segments
+\item \textbf{Operation Parameters}: Detailed inspection of layer parameters and attributes to understand computational complexity of each segment
+\end{itemize}
+
+Using Netron's interactive graph visualization, we identified strategic nodes in the U-Net encoder-decoder architecture where the model could be divided into four segments while maintaining the skip connection pathways essential for semantic segmentation accuracy. This analysis informed the split model implementation evaluated in Section~\ref{subsubsec:split-model-performance}, where intermediate tensors between segments are stored and passed to subsequent processing stages.
+
 \subsection{Resource Scheduling Implementation}\label{subsec:scheduling-implementation}
 
 \begin{itemize}


### PR DESCRIPTION
Add comprehensive documentation of Netron tool usage for identifying ONNX graph nodes to split the U-Net model into segments. Include:

- Citation for Netron in references.bib
- New subsubsection in implementation chapter explaining how Netron was used to visualize ONNX model graph structure
- Details on node identification, layer connectivity, tensor dimensions, and operation parameters that informed split point selection
- Cross-reference to split model performance evaluation

This documents the methodology used for model segmentation analysis and provides proper attribution to the Netron visualization tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Netron tool reference to bibliography
  * Documented ONNX graph visualization and analysis techniques used for model optimization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->