### PR TITLE
Add title logo to page

### DIFF
--- a/isusdd.cls
+++ b/isusdd.cls
@@ -129,6 +129,10 @@
 		\centering
 		\vspace*{1cm}
 
+		% Project logo
+		\includegraphics[width=0.25\textwidth]{assets/title-logo.png}\\
+		\vspace{1cm}
+
 		{\Large\textbf{\@institution}\\}
 		\vspace{0.5cm}
 		{\large\@department\\}


### PR DESCRIPTION
Added the title-logo.png to the document title page. The logo appears at the top of the title page, centered and sized at 25% of text width, above the institution name.

Location: isusdd.cls:133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a project logo to the title page for enhanced visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->