### PR TITLE
Add CI/CD pipeline

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,37 @@
           '';
       };
 
+      # Minimal CI/CD devShell optimized for automated builds
+      devShells.ci = pkgs.mkShell {
+        name = "latex-ci";
+
+        # Minimal packages needed for CI builds and testing
+        packages = with pkgs;
+          [
+            # Core LaTeX for compilation
+            texliveFull
+
+            # Nix formatter for CI checks
+            alejandra
+
+            # Git for version operations
+            git
+
+            # PDF utilities for validation
+            poppler_utils
+          ]
+          ++ builtins.attrValues scriptPackages
+          ++ preCommitCheck.enabledPackages;
+
+        shellHook = ''
+          echo "🤖 LaTeX CI Environment 🤖"
+          echo "Available commands:"
+          echo "  ltx-compile <file.tex>  - Compile LaTeX document"
+          echo "  lint                    - Run LaTeX linting"
+          echo "  ltx-wordcount <file.tex> - Count words in document"
+        '';
+      };
+
       formatter = treefmt-nix.lib.mkWrapper pkgs treefmtModule;
 
       checks.pre-commit-check = preCommitCheck;


### PR DESCRIPTION
Add a minimal CI-optimized devShell that includes only essential tools:
- texliveFull for LaTeX compilation
- alejandra for Nix formatting checks
- git for version operations
- poppler_utils for PDF validation
- All script packages (ltx-compile, lint, ltx-wordcount)
- Pre-commit hooks

This CI shell removes development-only tools like:
- Language servers (texlab, ltex-ls, nixd)
- IDE utilities (watchexec, pandoc)
- Static analysis tools (statix, deadnix)

Usage: nix develop .#ci