### PR TITLE
Center logo on title page

### DIFF
--- a/isusdd.cls
+++ b/isusdd.cls
@@ -130,7 +130,7 @@
 		\vspace*{1cm}
 
 		% Project logo
-		\includegraphics[width=0.25\textwidth]{assets/title-logo.png}\\
+		\includegraphics[width=0.6\textwidth]{assets/title-logo.png}\\
 		\vspace{1cm}
 
 		{\Large\textbf{\@institution}\\}


### PR DESCRIPTION
- Changed logo width from 25% to 60% of text width for better visibility
- Logo remains horizontally centered via existing \centering environment
- Improves visual prominence on title page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Increased the size of the logo image displayed on the title page to enhance visibility and visual prominence. The logo now occupies a significantly larger portion of the title page, improving its prominence, while all other title page elements and structure remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->