### PR TITLE
docs: clarify DPU is synthesized onto FPGA fabric via bitstream

### DIFF
--- a/documents/DesignDocSemester1.md
+++ b/documents/DesignDocSemester1.md
@@ -483,7 +483,7 @@ For risks with probability exceeding 30%, the team will develop detailed conting
 
 #### Hardware Resources
 
-- **Xilinx Kria Evaluation Board (Kv260):** Main development platform with built-in DPU for model inferences
+- **Xilinx Kria Evaluation Board (Kv260):** Main development platform with DPU synthesized onto FPGA fabric via bitstream for model inferences
 - **Development Computer:** Linux-based system for development, testing, and remote access to the board
 
 #### Software Resources
@@ -783,7 +783,7 @@ The team's project utilizes several key technologies, each with distinct strengt
 #### Kria Board KV260
 
 **Strengths:**
-- Built-in DPU (Deep Processing Unit) accelerates neural network inference
+- DPU (Deep Processing Unit) synthesized onto FPGA fabric via bitstream accelerates neural network inference
 - Multiple DDR4 memory banks enable parallel processing
 - Low power consumption suitable for mobile applications
 - Supports Vitis-AI for ML model optimization

--- a/sections/04-design.tex
+++ b/sections/04-design.tex
@@ -492,13 +492,13 @@ efficiency for our application:
   \centering
   \includegraphics[width=0.7\textwidth]{assets/kv260.png}
   \caption{AMD Kria KV260 Development Board featuring Zynq
-  UltraScale+ MPSoC with integrated DPU for AI acceleration.}~\label{fig:kv260}
+  UltraScale+ MPSoC with DPU synthesized onto FPGA fabric for AI acceleration.}~\label{fig:kv260}
 \end{figure}
 
 \begin{itemize}
   \item \textbf{Processing Power:} Quad-core ARM Cortex-A53 with 1.5
     GHz clock speed
-  \item \textbf{AI Acceleration:} Integrated DPU for neural network inference
+  \item \textbf{AI Acceleration:} DPU synthesized onto FPGA fabric via bitstream for neural network inference
   \item \textbf{Memory System:} 4GB DDR4 memory with four banks for
     parallel access
   \item \textbf{Connectivity:} Multiple I/O interfaces for camera


### PR DESCRIPTION
Replace all references to "integrated DPU" and "built-in DPU" with accurate language reflecting that the DPU is synthesized onto the KV260 FPGA fabric using a bitstream configuration, rather than being a hardwired/integrated component.

Changes:
- sections/04-design.tex: Updated figure caption and AI acceleration description
- documents/DesignDocSemester1.md: Updated hardware resources and strengths sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated descriptions of the Xilinx Kria KV260 hardware's DPU (Deep Processing Unit) to accurately reflect how it is synthesized onto FPGA fabric via bitstream for model inference acceleration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->