### PR TITLE
Remove disclaimer line from poster

### DIFF
--- a/poster/sections/results.tex
+++ b/poster/sections/results.tex
@@ -37,8 +37,3 @@ Continuous Operation & 24+ hours \\
   \item \textbf{IEEE compliance:} Testing per IEEE 3129--2023 \& IEEE 2802--2022
 \end{itemize}
 
-\vspace{1em}
-
-\textbf{Limitations:}
-
-This is a \textit{proof-of-concept}. Clinical validation with wheelchair users is required before deployment. Current focus: engineering performance, not medical efficacy.


### PR DESCRIPTION
Remove proof-of-concept disclaimer from the Results section. The "Limitations" heading and associated disclaimer text about clinical validation have been removed to present a more confident final poster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed limitations section from results documentation to streamline content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->