### PR TITLE
Update DPU references for synthesized FPGA implementation

### DIFF
--- a/sections/02-requirements.tex
+++ b/sections/02-requirements.tex
@@ -156,10 +156,10 @@ significantly shaped the design and optimization approach:
   \item \textbf{FPGA Fabric Modification Prohibition:}
     \begin{itemize}
       \item The team was explicitly directed not to modify or touch
-        the FPGA fabric containing the DPU\@.
+        the FPGA fabric or the DPU bitstream configuration.
       \item This constraint prevents hardware-level reconfiguration
         and requires all optimizations to be implemented at the software level.
-      \item The existing FPGA programming and DPU integration must
+      \item The existing FPGA bitstream (which synthesizes the DPU onto the programmable logic) must
         remain unchanged throughout development.
     \end{itemize}
 

--- a/sections/04-design.tex
+++ b/sections/04-design.tex
@@ -345,7 +345,7 @@ following key components:
     \begin{itemize}
       \item System-on-Module (SoM) with programmable logic
       \item Quad-core ARM processor
-      \item DPU for accelerating neural network inference
+      \item DPU synthesized onto FPGA fabric for accelerating neural network inference
       \item Four 1GB DDR4 memory banks
       \item Various I/O interfaces for camera input and system communication
     \end{itemize}
@@ -492,13 +492,13 @@ efficiency for our application:
   \centering
   \includegraphics[width=0.7\textwidth]{assets/kv260.png}
   \caption{AMD Kria KV260 Development Board featuring Zynq
-  UltraScale+ MPSoC with integrated DPU for AI acceleration.}~\label{fig:kv260}
+  UltraScale+ MPSoC with DPU synthesized onto FPGA fabric via bitstream for AI acceleration.}~\label{fig:kv260}
 \end{figure}
 
 \begin{itemize}
   \item \textbf{Processing Power:} Quad-core ARM Cortex-A53 with 1.5
     GHz clock speed
-  \item \textbf{AI Acceleration:} Integrated DPU for neural network inference
+  \item \textbf{AI Acceleration:} DPU synthesized onto FPGA fabric via bitstream for neural network inference
   \item \textbf{Memory System:} 4GB DDR4 memory with four banks for
     parallel access
   \item \textbf{Connectivity:} Multiple I/O interfaces for camera
@@ -578,7 +578,7 @@ ONNX Runtime~\cite{onnxruntime} provide essential tools for our optimization:
 
 The VART stack architecture (Figure~\ref{fig:vart-stack}) illustrates
 the complete software stack from the application layer down to the
-Deep Learning Processing Unit (DPU) hardware. This layered approach
+Deep Learning Processing Unit (DPU) synthesized onto the FPGA fabric. This layered approach
 enables efficient neural network inference by providing optimized
 runtime libraries and hardware abstraction layers that maximize
 utilization of the Kria KV260's acceleration capabilities.

--- a/sections/05-testing.tex
+++ b/sections/05-testing.tex
@@ -314,7 +314,7 @@ Integration}\label{subsec:hardware-software-integration}
 
 \begin{itemize}
   \item Tested camera integration and image capture reliability
-  \item Verified DPU scheduling worked correctly with FPGA programming
+  \item Verified DPU scheduling worked correctly with the FPGA bitstream configuration
   \item Validated memory management across hardware and software boundaries
 \end{itemize}
 


### PR DESCRIPTION
Replace references to "integrated DPU" with technically accurate descriptions that clarify the DPU is synthesized onto the KV260 FPGA fabric using a bitstream configuration, not a permanent built-in hardware component.

Changes:
- sections/04-design.tex: Update figure caption and multiple references to specify DPU is synthesized onto FPGA fabric
- sections/02-requirements.tex: Clarify FPGA bitstream constraint language
- sections/05-testing.tex: Update reference to FPGA bitstream configuration

This improves technical accuracy by distinguishing between programmable logic (FPGA fabric) and fixed silicon components.