### PR TITLE
style: align GitHub and Markdown links to right side of document items

### DIFF
--- a/www/css/site.css
+++ b/www/css/site.css
@@ -752,6 +752,8 @@ footer {
 }
 
 .pdf-link-container {
+  display: flex;
+  align-items: center;
   padding: 12px 15px;
   margin-bottom: 15px;
   border: 1px solid #eee;
@@ -973,7 +975,11 @@ footer {
 }
 
 /* Additional styling for icon links in document sections */
-.pdf-link-container .github-link,
+.pdf-link-container .github-link {
+  margin-left: auto;
+  font-size: 1em;
+}
+
 .pdf-link-container .markdown-link {
   margin-left: 10px;
   font-size: 1em;


### PR DESCRIPTION
## Summary
- Uses flexbox on `.pdf-link-container` to push GitHub and Markdown icon links to the right edge of each document row
- Improves visual hierarchy by separating document titles from action icons
- CSS-only change with no HTML modifications required

## Test plan
- [ ] Verify document links display correctly with icons on the right
- [ ] Check responsive behavior on mobile viewports
- [ ] Confirm hover states still work on all links

🤖 Generated with [Claude Code](https://claude.com/claude-code)