### PR TITLE
Add personal website links with icons

### DIFF
--- a/www/css/site.css
+++ b/www/css/site.css
@@ -972,13 +972,13 @@ footer {
 
 /* Team member GitHub profile links */
 .team-github-link {
-  display: block;
+  display: inline-block;
   color: #666;
   font-size: 1.2em;
   margin-top: 8px;
+  margin-right: 8px;
   transition: color 0.2s ease, transform 0.2s ease;
   cursor: pointer;
-  text-align: center;
 }
 
 .team-github-link:hover {
@@ -988,6 +988,26 @@ footer {
 }
 
 .team-github-link i {
+  pointer-events: none;
+}
+
+/* Team member personal website links */
+.team-website-link {
+  display: inline-block;
+  color: #666;
+  font-size: 1.2em;
+  margin-top: 8px;
+  transition: color 0.2s ease, transform 0.2s ease;
+  cursor: pointer;
+}
+
+.team-website-link:hover {
+  color: #c8102e;
+  transform: scale(1.15);
+  text-decoration: none;
+}
+
+.team-website-link i {
   pointer-events: none;
 }
 

--- a/www/index.html
+++ b/www/index.html
@@ -369,6 +369,9 @@
           <a href="https://github.com/TSSchaef" class="team-github-link" target="_blank" rel="noopener noreferrer" aria-label="Tyler Schaefer's GitHub profile">
             <i class="fab fa-github" aria-hidden="true"></i>
           </a>
+          <a href="https://schaefer-portfolio.vercel.app/" class="team-website-link" target="_blank" rel="noopener noreferrer" aria-label="Tyler Schaefer's personal website">
+            <i class="fas fa-globe" aria-hidden="true"></i>
+          </a>
           <p class="text-muted mt-3">
             Specializes in algorithm optimization and mathematical validation for ML models. Focuses on maintaining accuracy during the optimization and model splitting process.
           </p>
@@ -388,6 +391,9 @@
           <small class="text-muted member-position">ML Integration HWE</small>
           <a href="https://github.com/connerohnesorge" class="team-github-link" target="_blank" rel="noopener noreferrer" aria-label="Conner Ohnesorge's GitHub profile">
             <i class="fab fa-github" aria-hidden="true"></i>
+          </a>
+          <a href="https://conneroh.com" class="team-website-link" target="_blank" rel="noopener noreferrer" aria-label="Conner Ohnesorge's personal website">
+            <i class="fas fa-globe" aria-hidden="true"></i>
           </a>
           <p class="text-muted mt-3">
             Specializes in hardware optimization for ML models with experience in FPGA implementation. Also serves as the development environment manager.
@@ -409,6 +415,9 @@
           <a href="https://github.com/priedieux" class="team-github-link" target="_blank" rel="noopener noreferrer" aria-label="Aidan Perry's GitHub profile">
             <i class="fab fa-github" aria-hidden="true"></i>
           </a>
+          <a href="https://68e09a171bac372c31d8e988--dashing-cassata-2383a3.netlify.app/" class="team-website-link" target="_blank" rel="noopener noreferrer" aria-label="Aidan Perry's personal website">
+            <i class="fas fa-globe" aria-hidden="true"></i>
+          </a>
           <p class="text-muted mt-3">
             Leads threading implementation and synchronization for parallel processing. Experienced in real-time systems and FPGA programming.
           </p>
@@ -428,6 +437,9 @@
           <small class="text-muted member-position">Kria Board Manager</small>
           <a href="https://github.com/jjmetzen" class="team-github-link" target="_blank" rel="noopener noreferrer" aria-label="Joey Metzen's GitHub profile">
             <i class="fab fa-github" aria-hidden="true"></i>
+          </a>
+          <a href="https://joeymetzen.com" class="team-website-link" target="_blank" rel="noopener noreferrer" aria-label="Joey Metzen's personal website">
+            <i class="fas fa-globe" aria-hidden="true"></i>
           </a>
           <p class="text-muted mt-3">
             Responsible for hardware management and memory optimization. Leads testing and benchmarking efforts for the system.


### PR DESCRIPTION
Add globe icons next to GitHub icons for each team member linking to their personal websites:
- Tyler: schaefer-portfolio.vercel.app
- Conner: conneroh.com
- Aidan: netlify site
- Joey: joeymetzen.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personal website links for team members with globe icons, enabling direct access to individual portfolio sites alongside their existing GitHub profiles.

* **Style**
  * Improved team member link styling with inline-block layout and enhanced spacing. Refined hover interactions with color transitions and scale transformation effects.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->