### PR TITLE
Fix poster auto-download on hover

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1168,10 +1168,7 @@
                     development board platform.
                   </p>
 
-                  <div
-                    class="pdf-link-container"
-                    data-pdf-url="https://github.com/connerohnesorge/sddec25-01/releases/download/v1.3.5/sddec25-01-poster-v1.3.5.pdf"
-                  >
+                  <div class="pdf-link-container">
                     <a
                       href="https://github.com/connerohnesorge/sddec25-01/releases/download/v1.3.5/sddec25-01-poster-v1.3.5.pdf"
                       class="pdf-link"


### PR DESCRIPTION
Remove data-pdf-url attribute from poster link to prevent automatic PDF preview triggering on hover. External GitHub release URLs were causing unwanted download prompts when the hover preview attempted to load them in the iframe.